### PR TITLE
Make Stat component macroable

### DIFF
--- a/packages/widgets/src/StatsOverviewWidget/Stat.php
+++ b/packages/widgets/src/StatsOverviewWidget/Stat.php
@@ -4,6 +4,7 @@ namespace Filament\Widgets\StatsOverviewWidget;
 
 use Closure;
 use Filament\Support\Enums\IconPosition;
+use Filament\Support\Concerns\Macroable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Str;
@@ -12,6 +13,8 @@ use Illuminate\View\ComponentAttributeBag;
 
 class Stat extends Component implements Htmlable
 {
+    use Macroable;
+    
     /**
      * @var array<float> | null
      */


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Make the `Stat` component macroable like every other filament component

## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.
